### PR TITLE
Pull request to fix Travis CI integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ script:
   - py.test
   - if [[ $RUN_MYPY != false ]]; then mypy sgutils; fi
   - python setup.py bdist_wheel
-  - pip install ./dist/sgutils-*.whl
+  - pip install ./dist/cython_sgutils-*.whl
   - if [[ $PRE_COMMIT ]]; then pre-commit install; pre-commit run --all-files; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ matrix:
       env: RUN_MYPY=false
 
 install:
-  # Required for setup.py to parse.
-  - pip install Cython
-  - pip install .
+  - pip install .[dev]
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,18 @@ matrix:
   include:
     - python: 3.7
       env: PRE_COMMIT=true
+    - python: 3.7
+      env: CYTHON=false
     - python: 3.8
+    - python: 3.8
+      env: CYTHON=false
     - python: 3.9-dev
       env: RUN_MYPY=false
+    - python: 3.9-dev
+      env: CYTHON=false RUN_MYPY=false
 
 install:
+  - if [[ $CYTHON != false ]]; then pip install Cython; fi
   - pip install .[dev]
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,11 @@ matrix:
   include:
     - python: 3.7
       env: PRE_COMMIT=true
-    - python: 3.7
-      env: CYTHON=false
     - python: 3.8
-    - python: 3.8
-      env: CYTHON=false
     - python: 3.9-dev
       env: RUN_MYPY=false
-    - python: 3.9-dev
-      env: CYTHON=false RUN_MYPY=false
 
 install:
-  - if [[ $CYTHON != false ]]; then pip install Cython; fi
   - pip install .[dev]
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
       - libsgutils2-dev
 
 script:
-  - py.test
   - if [[ $RUN_MYPY != false ]]; then mypy sgutils; fi
   - python setup.py bdist_wheel
   - pip install ./dist/cython_sgutils-*.whl

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ matrix:
       env: RUN_MYPY=false
 
 install:
-  - pip install .[all]
+  # Required for setup.py to parse.
+  - pip install Cython
+  - pip install .
 
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+<a href="https://travis-ci.org/glucometers-tech/cython-sgutils/builds/"><img alt="build status" src="https://img.shields.io/travis/glucometers-tech/cython-sgutils"></a>
+<a href="https://github.com/glucometers-tech/cython-sgutils#license"><img alt="GitHub" src="https://img.shields.io/badge/license-MIT-green"></a>
+<a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+</p>
+
 # cython-sgutils
 
 Cython-based wrapper for libsgutils, that allows sending generic SCSI

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,5 @@
 [mypy]
 python_version = 3.7
+
+[mypy-sgutils.csgutils]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@
 # verbose regular expressions by Black.  Use [ ] to denote a significant space
 # character.
 
+[build-system]
+requires = ['cython']
+
 [tool.black]
 line-length = 88
 target-version = ['py37']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,12 @@
 # character.
 
 [build-system]
-requires = ['setuptools', 'wheel', 'cython']
+requires = [
+  'setuptools >= 42',
+  'wheel',
+  'Cython',
+  'setuptools_scm[toml]>=3.4',
+]
 
 [tool.black]
 line-length = 88
@@ -29,3 +34,5 @@ line_length = 88
 multi_line_output = 3
 include_trailing_comma = true
 known_first_party = ['sgutils']
+
+[tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # character.
 
 [build-system]
-requires = ['cython']
+requires = ['setuptools', 'wheel', 'cython']
 
 [tool.black]
 line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+license_files =
+   AUTHORS

--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,5 @@ setup(
             )
         ]
     ),
+    extras_require={"dev": ["mypy", "pre-commit"],},
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,16 @@
 
 from setuptools import Extension, find_packages, setup
 
-from Cython.Build import cythonize
+try:
+    from Cython.Build import cythonize
+
+    src_extension = ".pyx"
+except ImportError:
+    src_extension = ".c"
+
+    def cythonize(extensions):
+        return extensions
+
 
 with open("README.md", "rt") as fh:
     long_description = fh.read()
@@ -29,7 +38,9 @@ setup(
     ext_modules=cythonize(
         [
             Extension(
-                "sgutils.csgutils", ["sgutils/csgutils.pyx"], libraries=["sgutils2"],
+                "sgutils.csgutils",
+                ["sgutils/csgutils" + src_extension],
+                libraries=["sgutils2"],
             )
         ]
     ),

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from distutils.extension import Extension
-
-from setuptools import find_packages, setup
+from setuptools import Extension, find_packages, setup
 
 from Cython.Build import cythonize
 
@@ -28,7 +26,6 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     packages=find_packages(),
-    setup_requires=["Cython"],
     ext_modules=cythonize(
         [
             Extension(

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,8 @@
 
 from setuptools import Extension, find_packages, setup
 
-try:
-    from Cython.Build import cythonize
-
-    src_extension = ".pyx"
-except ImportError:
-    src_extension = ".c"
-
-    def cythonize(extensions):
-        return extensions
-
+import setuptools_scm  # Ensure it's present.
+from Cython.Build import cythonize
 
 with open("README.md", "rt") as fh:
     long_description = fh.read()
@@ -38,11 +30,9 @@ setup(
     ext_modules=cythonize(
         [
             Extension(
-                "sgutils.csgutils",
-                ["sgutils/csgutils" + src_extension],
-                libraries=["sgutils2"],
+                "sgutils.csgutils", ["sgutils/csgutils.pyx"], libraries=["sgutils2"],
             )
         ]
     ),
-    extras_require={"dev": ["mypy", "pre-commit"],},
+    extras_require={"dev": ["mypy", "pre-commit", "Cython", "setuptools_scm"],},
 )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ with open("README.md", "rt") as fh:
 
 setup(
     name="cython-sgutils",
-    version="1",
     description="Cython-based bindings for libsgutils",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     packages=find_packages(),
+    package_data={"": ["*.pyx", "*.pxd"]},
     ext_modules=cythonize(
         [
             Extension(


### PR DESCRIPTION
## Make sure to install Cython first.


## Fix package name to install.


## Make sure to use the correct `Extension` class.

Also make it clear that the Cython extension is required in pip.

## Add setuptools and wheel as required components.


## Add license information to setup.cfg.

This should stop the build from including AUTHORS~ in the distribution.

## Make sure to install pre-commit and mypy.

Also remove the explicit install of cython now that it's listed in pyproject.toml.

## Ignore missing type hints for csgutils.

Until Cython starts generating typing stubs, this is probably easier.

## Make `setup.py` work even without Cython installed.


## Make sure to distribute the cython sources even if cython is not availabel.


## Add shields to the README.


## Remove py.test from Travis.

There is no test for this just yet, for now ignore that part, assume if it builds and mypy passes, it's fine.

## Include both builds _with_ and _without_ Cython.


## Add setuptools_scm for versioning information.


## Make development dependencies a requirement on Travis CI.

This goes against the advice of Cython upstream to not require Cython at
build-time, but it makes the setup much simpler to read, and with PEP 518
there shouldn't be dependencies issue coming up on pip either.

Also this uses the SCM for versioning, which should be much safer.
