### PR TITLE
Move static descriptions to `setup.cfg` simplifying `setup.py`.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,18 @@
 [metadata]
+name = cython-sgutils
+description = Cython-based bindings for libsgutils
+url = https://github.com/glucometers-tech/cython-sgutils
 license_files =
    AUTHORS
+long_description = file:README.md
+long_description_content_type: text/markdown
+author = Diego Elio Pettenò
+author_email = flameeyes@flameeyes.com
+license = MIT
+keywords =
+    scsi
+classifiers =
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: MIT License

--- a/setup.py
+++ b/setup.py
@@ -7,24 +7,7 @@ from setuptools import Extension, find_packages, setup
 import setuptools_scm  # Ensure it's present.
 from Cython.Build import cythonize
 
-with open("README.md", "rt") as fh:
-    long_description = fh.read()
-
 setup(
-    name="cython-sgutils",
-    description="Cython-based bindings for libsgutils",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Diego Elio Pettenò",
-    author_email="flameeyes@flameeyes.com",
-    url="https://github.com/glucometers-tech/cython-sgutils",
-    keywords=["scsi"],
-    classifiers=[
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Development Status :: 4 - Beta",
-        "License :: OSI Approved :: MIT License",
-    ],
     packages=find_packages(),
     package_data={"": ["*.pyx", "*.pxd"]},
     ext_modules=cythonize(


### PR DESCRIPTION
This removes a number of fixed strings from the Python side of the setup,
and prefers referencing the `README.md` file by name.